### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,12 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [7.3, 7.4, 8.0]
-                laravel: [6.*, 7.*, 8.*]
+                php: [7.3, 7.4, 8.0, 8.1]
+                laravel: [6.*, 7.*, 8.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
+                    -   laravel: 9.*
+                        testbench: 7.*
                     -   laravel: 8.*
                         testbench: 6.*
                     -   laravel: 7.*
@@ -20,6 +22,11 @@ jobs:
                     -   laravel: 6.*
                         testbench: 4.*
                 exclude:
+                    # excludes laravel 6+7 on php8.1
+                    -   php: 8.1
+                        laravel: 6.*
+                    -   php: 8.1
+                        laravel: 7.*
                     # excludes laravel 6+7 on php8
                     -   php: 8.0
                         laravel: 6.*
@@ -30,7 +37,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v1
+                uses: actions/checkout@v2
 
             -   name: Install SQLite 3
                 run: |
@@ -38,7 +45,7 @@ jobs:
                     sudo apt-get install sqlite3
                     sudo apt-get install redis
             -   name: Cache dependencies
-                uses: actions/cache@v1
+                uses: actions/cache@v2
                 with:
                     path: ~/.composer/cache/files
                     key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
 
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 php: [7.3, 7.4, 8.0, 8.1]
                 laravel: [6.*, 7.*, 8.*, 9.*]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,6 +22,11 @@ jobs:
                     -   laravel: 6.*
                         testbench: 4.*
                 exclude:
+                    # excludes php7.3, php7.4 for laravel 9
+                    -   php: 7.3
+                        laravel: 9.*
+                    -   php: 7.4
+                        laravel: 9.*
                     # excludes laravel 6+7 on php8.1
                     -   php: 8.1
                         laravel: 6.*

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/support": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0",
+        "php": "^7.3 || ^8.0",
+        "illuminate/support": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "jaybizzle/crawler-detect": "^1.2",
         "spatie/laravel-referer": "^1.6",
         "torann/geoip": "^1.0|^3.0"
     },
     "require-dev": {
         "doctrine/dbal": "^2.6|^3.0",
-        "illuminate/support": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0",
-        "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^3.5 || ^3.6 || ^3.7 || ^3.8 || ^4.0 || ^5.0 || ^6.0",
+        "illuminate/support": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "mockery/mockery": "^1.4 || ^2.0",
+        "orchestra/testbench": "^3.5 || ^3.6 || ^3.7 || ^3.8 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^9.3",
         "predis/predis": "^1.1"
     },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,7 +32,7 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         $this->app['config']->set('geoip', array_merge(require __DIR__ . '/../vendor/torann/geoip/config/geoip.php'));
-        $this->app['router']->get('/')->middleware(CaptureReferer::class, function () {
+        $this->app['router']->middleware(CaptureReferer::class)->get('/', function () {
             return response(null, 200);
         });
         $this->session = $this->app['session.store'];


### PR DESCRIPTION
This PR adds support for Laravel 9. I updated the "fail fast" parameter to see which workflows are running correctly.
Currently, one workflow fails. I am not quite sure how to fix it.