### PR TITLE
Fix PostgreSQL compatibility for eager loading visits

### DIFF
--- a/src/Relations/VisitsHasOne.php
+++ b/src/Relations/VisitsHasOne.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Awssat\Visits\Relations;
+
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Model;
+
+class VisitsHasOne extends HasOne
+{
+    /**
+     * Get all of the primary keys for an array of models.
+     *
+     * @param  array  $models
+     * @param  string|null  $key
+     * @return array
+     */
+    protected function getKeys(array $models, $key = null)
+    {
+        return collect($models)->map(function ($value) use ($key) {
+            return (string) ($key ? $value->getAttribute($key) : $value->getKey());
+        })->values()->unique(null, true)->sort()->all();
+    }
+
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(Model $model, $key)
+    {
+        return 'whereIn';
+    }
+}

--- a/src/Visits.php
+++ b/src/Visits.php
@@ -3,6 +3,7 @@
 namespace Awssat\Visits;
 
 use Awssat\Visits\Models\Visit;
+use Awssat\Visits\Relations\VisitsHasOne;
 use Awssat\Visits\Traits\{Lists, Periods, Record, Setters};
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -271,6 +272,12 @@ class Visits
     {
         $prefix = $this->config['keys_prefix'] ?? $this->config['redis_keys_prefix'] ?? 'visits';
         
-        return $this->subject->hasOne(Visit::class, 'secondary_key')->where('primary_key', $prefix.':'.$this->keys->visits);
+        $instance = new Visit;
+        $foreignKey = 'secondary_key';
+        $localKey = $this->subject->getKeyName();
+
+        $relation = new VisitsHasOne($instance->newQuery(), $this->subject, $instance->getTable().'.'.$foreignKey, $localKey);
+
+        return $relation->where('primary_key', $prefix.':'.$this->keys->visits);
     }
 }

--- a/tests/Feature/PostgresCompatibilityTest.php
+++ b/tests/Feature/PostgresCompatibilityTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Awssat\Visits\Tests\Feature;
+
+use Awssat\Visits\Tests\TestCase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Eloquent\Model;
+
+class TestPost extends Model
+{
+    protected $table = 'posts';
+    protected $guarded = [];
+
+    public function visits()
+    {
+        return visits($this)->relation();
+    }
+}
+
+class PostgresCompatibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['config']['visits.engine'] = \Awssat\Visits\DataEngines\EloquentEngine::class;
+        include_once __DIR__.'/../../database/migrations/create_visits_table.php.stub';
+        (new \CreateVisitsTable())->up();
+    }
+
+    /** @test */
+    public function it_generates_correct_query_types_for_postgres()
+    {
+        $post1 = TestPost::create(['name' => 'p1']);
+        $post2 = TestPost::create(['name' => 'p2']);
+
+        visits($post1)->increment();
+        visits($post2)->increment();
+
+        DB::enableQueryLog();
+
+        $posts = TestPost::with('visits')->get();
+
+        $log = DB::getQueryLog();
+
+        // Find the query that loads visits
+        $visitsQuery = null;
+        foreach ($log as $query) {
+            if (strpos($query['query'], 'select * from "visits"') !== false) {
+                $visitsQuery = $query;
+                break;
+            }
+        }
+
+        // If not found, look for standard select
+        if (!$visitsQuery) {
+            foreach ($log as $query) {
+                if (strpos($query['query'], 'from "visits"') !== false) {
+                    $visitsQuery = $query;
+                    break;
+                }
+            }
+        }
+
+        $this->assertNotNull($visitsQuery, 'Visits query not found');
+
+        // Check bindings
+        $bindings = $visitsQuery['bindings'];
+
+        $hasIntegerBindings = false;
+        $hasStringBindings = false;
+
+        foreach ($bindings as $binding) {
+            if (is_int($binding) && ($binding === $post1->id || $binding === $post2->id)) {
+                $hasIntegerBindings = true;
+            }
+             if (is_string($binding) && ($binding === (string) $post1->id || $binding === (string) $post2->id)) {
+                $hasStringBindings = true;
+            }
+        }
+
+        $this->assertFalse($hasIntegerBindings, 'Bindings should not be integers');
+        $this->assertTrue($hasStringBindings, 'Bindings should be strings');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,9 @@ abstract class TestCase extends BaseTestCase
     protected $redis;
     protected $connection;
 
+    /** @var \Illuminate\Testing\TestResponse|null */
+    protected static $latestResponse = null;
+
     /**
      * Setup the test environment.
      *


### PR DESCRIPTION
Fixes PostgreSQL compatibility issue where eager loading the `visits` relationship fails with "operator does not exist: character varying = integer". This is achieved by creating a custom `VisitsHasOne` relation that casts model keys to strings and forces the use of string bindings in the query.

---
