### PR TITLE
⚡ [performance] Fix N+1 Database Delete in Reset::periods()

### DIFF
--- a/src/DataEngines/EloquentEngine.php
+++ b/src/DataEngines/EloquentEngine.php
@@ -49,14 +49,22 @@ class EloquentEngine implements DataEngine
 
     public function delete($key, $member = null): bool
     {
-        if(is_array($key)) {
-            array_walk($key, function($item) {
-                $this->delete($item);
+        if (is_array($key) && (empty($member) && !is_numeric($member))) {
+            $keys = array_map(function ($item) {
+                return $this->prefix . $item;
+            }, $key);
+
+            return $this->model->whereIn('primary_key', $keys)->delete() > 0;
+        }
+
+        if (is_array($key)) {
+            array_walk($key, function ($item) use ($member) {
+                $this->delete($item, $member);
             });
             return true;
         }
 
-        if(! empty($member) || is_numeric($member)) {
+        if (!empty($member) || is_numeric($member)) {
             return $this->model->where(['primary_key' => $this->prefix.$key, 'secondary_key' => $member])->delete();
         } else {
             return $this->model->where(['primary_key' => $this->prefix.$key])->delete();

--- a/src/DataEngines/RedisEngine.php
+++ b/src/DataEngines/RedisEngine.php
@@ -59,9 +59,17 @@ class RedisEngine implements DataEngine
 
     public function delete($key, $member = null): bool
     {
+        if (is_array($key) && (empty($member) && !is_numeric($member))) {
+            $keys = array_map(function ($item) {
+                return $this->prefix . $item;
+            }, $key);
+
+            return $this->connection->del($keys) > 0;
+        }
+
         if (is_array($key)) {
-            array_walk($key, function ($item) {
-                $this->delete($item);
+            array_walk($key, function ($item) use ($member) {
+                $this->delete($item, $member);
             });
             return true;
         }

--- a/src/Reset.php
+++ b/src/Reset.php
@@ -98,10 +98,16 @@ class Reset extends Visits
      */
     public function periods()
     {
+        $keys = [];
+
         foreach ($this->periods as $period => $_) {
             $periodKey = $this->keys->period($period);
-            $this->connection->delete($periodKey);
-            $this->connection->delete($periodKey.'_total');
+            $keys[] = $periodKey;
+            $keys[] = $periodKey . '_total';
+        }
+
+        if (count($keys)) {
+            $this->connection->delete($keys);
         }
     }
 


### PR DESCRIPTION
The `Reset::periods()` method had an N+1 issue where it would call `$this->connection->delete()` twice for each period (once for the period key and once for the `_total` key). This resulted in multiple database/Redis calls.

I optimized this by:
1. Collecting all keys that need to be deleted into an array within `Reset::periods()`.
2. Calling `$this->connection->delete($keys)` once.
3. Updating `RedisEngine` and `EloquentEngine` to handle array inputs for `delete` by using bulk operation commands (`DEL` for Redis, `whereIn` for Eloquent).
4. Ensuring that if an array of keys is passed WITH a `member`, it still correctly delegates to individual deletions (preserving the behavior for sorted sets/filtered Eloquent deletes).

Benchmark verification showed a reduction from 2N calls to 1 call per execution of `periods()`.
