### PR TITLE
⚡ Optimize Redis bulk key deletion

### DIFF
--- a/src/DataEngines/RedisEngine.php
+++ b/src/DataEngines/RedisEngine.php
@@ -60,8 +60,21 @@ class RedisEngine implements DataEngine
     public function delete($key, $member = null): bool
     {
         if (is_array($key)) {
-            array_walk($key, function ($item) {
-                $this->delete($item);
+            if (empty($key)) {
+                return true;
+            }
+
+            if (empty($member) && !is_numeric($member)) {
+                $keys = array_map(function ($item) {
+                    return $this->prefix . $item;
+                }, $key);
+
+                $this->connection->del(...$keys);
+                return true;
+            }
+
+            array_walk($key, function ($item) use ($member) {
+                $this->delete($item, $member);
             });
             return true;
         }


### PR DESCRIPTION
💡 **What:** Optimized `RedisEngine::delete` to use a single Redis `DEL` command when an array of keys is provided (and no member is specified). Also fixed a bug where the `$member` parameter was not passed during recursive deletions.

🎯 **Why:** The previous implementation used `array_walk` to delete keys individually, resulting in N network roundtrips to Redis. This optimization reduces it to 1 call for bulk deletions.

📊 **Measured Improvement:**
- **Bulk deletion (5 keys):** Reduced from 5 Redis `DEL` calls to 1.
- **Member deletion:** Fixed bug where `$member` was lost during recursion; it now correctly performs `ZREM` calls for each key with the specified member.
- **Safety:** Added check for empty arrays to prevent errors when calling `del` with no arguments.
- **Consistency:** Maintained original return value behavior (`true` for arrays) to ensure backward compatibility.
