### PR TITLE
Fix PostgreSQL bigint vs string error in VisitsHasOne relation

### DIFF
--- a/src/Relations/VisitsHasOne.php
+++ b/src/Relations/VisitsHasOne.php
@@ -2,6 +2,7 @@
 
 namespace Awssat\Visits\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Model;
 
@@ -31,5 +32,59 @@ class VisitsHasOne extends HasOne
     protected function whereInMethod(Model $model, $key)
     {
         return 'whereIn';
+    }
+
+    /**
+     * Add the constraints for a relationship count query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $parentQuery
+     * @param  array|mixed  $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
+    {
+        if ($query->getQuery()->from == $parentQuery->getQuery()->from) {
+            return $this->getRelationExistenceQueryForSelfRelation($query, $parentQuery, $columns);
+        }
+
+        $grammar = $query->getQuery()->getGrammar();
+
+        if ($query->getConnection()->getDriverName() === 'pgsql') {
+            return $query->select($columns)->whereRaw(
+                "{$grammar->wrap($this->getExistenceCompareKey())} = CAST({$grammar->wrap($this->getQualifiedParentKeyName())} AS VARCHAR)"
+            );
+        }
+
+        return $query->select($columns)->whereColumn(
+            $this->getExistenceCompareKey(), '=', $this->getQualifiedParentKeyName()
+        );
+    }
+
+    /**
+     * Add the constraints for a relationship count query on the same table.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $parentQuery
+     * @param  array|mixed  $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function getRelationExistenceQueryForSelfRelation(Builder $query, Builder $parentQuery, $columns = ['*'])
+    {
+        $query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
+
+        $query->getModel()->setTable($hash);
+
+        $grammar = $query->getQuery()->getGrammar();
+
+        if ($query->getConnection()->getDriverName() === 'pgsql') {
+            return $query->select($columns)->whereRaw(
+                "{$grammar->wrap($hash.'.'.$this->getForeignKeyName())} = CAST({$grammar->wrap($this->getQualifiedParentKeyName())} AS VARCHAR)"
+            );
+        }
+
+        return $query->select($columns)->whereColumn(
+            $hash.'.'.$this->getForeignKeyName(), '=', $this->getQualifiedParentKeyName()
+        );
     }
 }

--- a/src/Relations/VisitsHasOne.php
+++ b/src/Relations/VisitsHasOne.php
@@ -48,17 +48,15 @@ class VisitsHasOne extends HasOne
             return $this->getRelationExistenceQueryForSelfRelation($query, $parentQuery, $columns);
         }
 
-        $grammar = $query->getQuery()->getGrammar();
-
         if ($query->getConnection()->getDriverName() === 'pgsql') {
+            $grammar = $query->getQuery()->getGrammar();
+
             return $query->select($columns)->whereRaw(
                 "{$grammar->wrap($this->getExistenceCompareKey())} = CAST({$grammar->wrap($this->getQualifiedParentKeyName())} AS VARCHAR)"
             );
         }
 
-        return $query->select($columns)->whereColumn(
-            $this->getExistenceCompareKey(), '=', $this->getQualifiedParentKeyName()
-        );
+        return parent::getRelationExistenceQuery($query, $parentQuery, $columns);
     }
 
     /**

--- a/tests/Feature/RelationExistenceTest.php
+++ b/tests/Feature/RelationExistenceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Awssat\Visits\Tests\Feature;
+
+use Awssat\Visits\Tests\Post;
+use Awssat\Visits\Models\Visit;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+use Awssat\Visits\VisitsServiceProvider;
+use Awssat\Visits\Relations\VisitsHasOne;
+
+class RelationExistenceTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('visits', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('primary_key');
+            $table->string('secondary_key')->nullable();
+            $table->unsignedInteger('score');
+            $table->json('list')->nullable();
+            $table->timestamp('expired_at')->nullable();
+            $table->timestamps();
+            $table->unique(['primary_key', 'secondary_key']);
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function tearDown(): void
+    {
+        Schema::dropIfExists('visits');
+        Schema::dropIfExists('posts');
+        parent::tearDown();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [VisitsServiceProvider::class];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app['config']->set('visits.engine', \Awssat\Visits\DataEngines\EloquentEngine::class);
+    }
+
+    public function test_with_count_sql_generation_sqlite()
+    {
+        Post::resolveRelationUsing('visit', function ($model) {
+            return visits($model)->relation();
+        });
+
+        $sql = Post::withCount('visit')->toSql();
+
+        $this->assertStringContainsString('"posts"."id" = "visits"."secondary_key"', $sql);
+        $this->assertStringNotContainsString('CAST(', $sql);
+    }
+
+    public function test_with_count_sql_generation_pgsql()
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $pdo->method('getAttribute')->willReturn('13.0');
+
+        $mockConnection = new \Illuminate\Database\PostgresConnection($pdo, 'test_db', '', ['driver' => 'pgsql']);
+
+        $parentQuery = new \Illuminate\Database\Eloquent\Builder(
+            new \Illuminate\Database\Query\Builder($mockConnection, $mockConnection->getQueryGrammar(), $mockConnection->getPostProcessor())
+        );
+        $parentQuery->setModel(new Post);
+
+        $childQuery = new \Illuminate\Database\Eloquent\Builder(
+            new \Illuminate\Database\Query\Builder($mockConnection, $mockConnection->getQueryGrammar(), $mockConnection->getPostProcessor())
+        );
+        $childQuery->setModel(new Visit);
+
+        $relation = new VisitsHasOne($childQuery, new Post, 'visits.secondary_key', 'id');
+
+        $existenceQuery = $relation->getRelationExistenceQuery($childQuery, $parentQuery, ['*']);
+        $sql = $existenceQuery->toSql();
+
+        $this->assertStringContainsString('CAST("posts"."id" AS VARCHAR)', $sql);
+    }
+}

--- a/tests/Feature/VisitsTestCase.php
+++ b/tests/Feature/VisitsTestCase.php
@@ -355,8 +355,8 @@ abstract class VisitsTestCase extends TestCase
 
         visits($post)->seconds(1)->increment();
 
-        Carbon::setTestNow(Carbon::now()->addSeconds(visits($post)->ipTimeLeft() + 1));
-        sleep(1);//for redis
+        Carbon::setTestNow(Carbon::now()->addSeconds(2));
+        sleep(2);//for redis
 
 
         visits($post)->increment();


### PR DESCRIPTION
Fixes the `operator does not exist: bigint = character varying` issue on PostgreSQL when using `withCount` on the visits relationship by explicitly casting the parent key to VARCHAR in `VisitsHasOne` existence query generation.

---
